### PR TITLE
Issue #26 - truncate displayed statistics to 2 decimal places.

### DIFF
--- a/gui/data_filler.py
+++ b/gui/data_filler.py
@@ -70,9 +70,9 @@ class DataFiller():
 
         if name in self._monitors:
             # Mean
-            self._monitors[name].label_statvalues[0].setText(str(np.mean(self._data[name])))
+            self._monitors[name].label_statvalues[0].setText("%.2f" % np.mean(self._data[name]))
             # Max
-            self._monitors[name].label_statvalues[1].setText(str(np.max(self._data[name])))
+            self._monitors[name].label_statvalues[1].setText("%.2f" % np.max(self._data[name]))
             # Value
             self._monitors[name].update(self._data[name][-1])
         else:

--- a/gui/monitor/monitor.py
+++ b/gui/monitor/monitor.py
@@ -68,7 +68,7 @@ class Monitor(QtWidgets.QWidget):
         value: The value that the monitor will display.
         """
         self.value = value;
-        self.label_value.setText(str(value))
+        self.label_value.setText("%.2f" % value)
 
         # handle palette changes due to alarm
         if self.is_alarm():


### PR DESCRIPTION
Truncates the current/mean/max displayed values to 2 decimal places, so the most significant digits are always visible.