### PR TITLE
Turn off mouse interaction on plots and removing AdaptiveDecimalStepType

### DIFF
--- a/gui/data_filler.py
+++ b/gui/data_filler.py
@@ -32,6 +32,7 @@ class DataFiller():
         self._plots[name].setData(self._xdata, self._data[name])
 
         plot.setLabel(axis='left', text=to_units.get(name, ''))
+        plot.setMouseEnabled(x=False, y=False)
 
     def connect_monitor(self, name, monitor):
         '''

--- a/gui/settings/settings.ui
+++ b/gui/settings/settings.ui
@@ -161,9 +161,6 @@ QDoubleSpinBox::down-button  {
       <property name="singleStep">
        <double>0.100000000000000</double>
       </property>
-      <property name="stepType">
-       <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
-      </property>
      </widget>
     </widget>
     <widget class="QWidget" name="tab_2">


### PR DESCRIPTION
- pyqtgraph plots are interactive by default. This PR turns it off as we don't want users to accidentally zoom in into plots.
- I'm removing AdaptiveDecimalStepType from the settings.ui files, as in some Qt versions it is not available.