### PR TITLE
remove hard-coded python3 paths from shell headers

### DIFF
--- a/gui/data_handler.py
+++ b/gui/data_handler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import sys, traceback
 import time
 from PyQt5.QtCore import QThreadPool

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 from PyQt5 import QtWidgets, uic
 from PyQt5 import QtCore, QtGui, QtWidgets
 

--- a/gui/monitor/monitor.py
+++ b/gui/monitor/monitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 from PyQt5 import QtWidgets, uic
 from PyQt5 import QtGui
 import sys

--- a/gui/mvm_gui.py
+++ b/gui/mvm_gui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 '''
 Runs the MVM GUI
 '''

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 from PyQt5 import QtWidgets, uic
 from PyQt5 import QtCore, QtGui, QtWidgets
 

--- a/gui/toolsettings/toolsettings.py
+++ b/gui/toolsettings/toolsettings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 from PyQt5 import QtWidgets, uic
 import sys
 


### PR DESCRIPTION
Just a suggestion so one can run the gui in a virtual environment - useful for development, and possibly for deployment.
