### PR TITLE
Fixes #52

### DIFF
--- a/gui/default_settings.yaml
+++ b/gui/default_settings.yaml
@@ -13,6 +13,15 @@ sampling_interval: 0.1
 # The parameters that will be read from the ESP and stored for possible use
 read_params: ['pressure', 'flow', 'o2', 'bpm', 'all']
 
+# The parameters that can be set on the ESP
+# The values below must match those used in the ESP
+esp_settable_param:
+    respiratory_rate: 'rate'
+    insp_expir_ratio: 'ratio'
+    pressure_trigger: 'assist_ptrigger'
+    flow_trigger: 'assist_flow_min'
+
+
 # This is the string returned by the ESP in case of success
 return_success_code: 'OK'
 

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -143,8 +143,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.button_startstop, 
                 self.button_autoassist)
 
-        self.button_startstop.pressed.connect(self._start_stop_worker.toggle_start_stop)
-        self.button_autoassist.pressed.connect(self._start_stop_worker.toggle_mode)
+        self.button_startstop.released.connect(self._start_stop_worker.toggle_start_stop)
+        self.button_autoassist.released.connect(self._start_stop_worker.toggle_mode)
 
         '''
         Connect settings button to Settings overlay.

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -96,10 +96,10 @@ class Settings(QtWidgets.QMainWindow):
         self._current_values['respiratory_rate'] = rr['default']
 
         ie = self._config['insp_expir_ratio']
-        self._insp_expir_ratio_input.setValue(ie['default'])
-        self._insp_expir_ratio_input.setMinimum(ie['min'])
-        self._insp_expir_ratio_input.setMaximum(ie['max'])
-        self._current_values['insp_expir_ratio'] = ie['default']
+        self._insp_expir_ratio_input.setValue(1./ie['default'])
+        self._insp_expir_ratio_input.setMinimum(1./ie['max'])
+        self._insp_expir_ratio_input.setMaximum(1./ie['min'])
+        self._current_values['insp_expir_ratio'] = 1./ie['default']
 
         self.resp_rate_worker()
         self.insp_expir_ratio_worker()
@@ -215,7 +215,8 @@ class Settings(QtWidgets.QMainWindow):
         # Set color to red until we know the value has been set.
         self._respiratory_rate_input.setStyleSheet("color: red")
 
-        status = self._data_h.set_data('rate', rr)
+        esp_param_name = self._config['esp_settable_param']['respiratory_rate']
+        status = self._data_h.set_data(esp_param_name, rr)
 
         if status == True:
             # Now set the color to green, as we know it has been set
@@ -231,7 +232,7 @@ class Settings(QtWidgets.QMainWindow):
 
         ratio = self._current_values['insp_expir_ratio']
 
-        if self._debug: print('value of Ratio', ratio)
+        if self._debug: print('Setting I:E to', ratio)
 
         # Update the value in the config file
         self._config['insp_expir_ratio']['current'] = ratio
@@ -239,14 +240,18 @@ class Settings(QtWidgets.QMainWindow):
         # Set color to red until we know the value has been set.
         self._insp_expir_ratio_input.setStyleSheet("color: red")
 
-        status = self._data_h.set_data('ratio', ratio)
+        esp_param_name = self._config['esp_settable_param']['insp_expir_ratio']
+        status = self._data_h.set_data(esp_param_name, ratio)
 
-        if status == True:
+        if status:
             # Now set the color to green, as we know it has been set
             self._insp_expir_ratio_input.setStyleSheet("color: green")
 
+        else:
+            print(f"\033[91mERROR: Can't set data for ESP with param {name}.\033[0m")
+
         # Finally, update the value in the toolsettings
-        self._toolsettings[1].update(1/ratio)
+        self._toolsettings[1].update(ratio)
 
 
     def send_assist_values_to_hardware(self):
@@ -267,7 +272,8 @@ class Settings(QtWidgets.QMainWindow):
         # Set color to red until we know the value has been set.
         self._pressure_trigger_input.setStyleSheet("color: red")
 
-        status = self._data_h.set_data('assist_ptrigger', pressure)
+        esp_param_name = self._config['esp_settable_param']['pressure_trigger']
+        status = self._data_h.set_data(esp_param_name, pressure)
 
         if status == True:
             # Now set the color to green, as we know it has been set
@@ -288,7 +294,8 @@ class Settings(QtWidgets.QMainWindow):
         # Set color to red until we know the value has been set.
         self._flow_trigger_input.setStyleSheet("color: red")
 
-        status = self._data_h.set_data('assist_flow_min', flow)
+        esp_param_name = self._config['esp_settable_param']['flow_trigger']
+        status = self._data_h.set_data(esp_param_name, flow)
 
         if status == True:
             # Now set the color to green, as we know it has been set


### PR DESCRIPTION
- Fixes #52 

- With this PR, the I:E value passed to the ESP is fixed (before we were passing 1/I:E).

- The ranges that allow to set values in the denominator in the settings panel are now correct. One can set values bigger than 1, so as to obtain I:E <=1.

- The parameters used to set values in the ESP are now configurable from the yaml file.
