### PR TITLE
Issue 53

### DIFF
--- a/gui/default_settings.yaml
+++ b/gui/default_settings.yaml
@@ -2,7 +2,7 @@
 port: '/dev/cu.usbmodem141301'
 
 # If false, opens the GUI but doesn't read data:
-read_from_esp: True
+read_from_esp: False
 
 # Number of samples to display in the graphs:
 nsamples: 100
@@ -97,17 +97,23 @@ monitor_bot:
 
 # Respiration Rate (breaths per minute)
 respiratory_rate:
+    name: "Resp. Rate"
     default: 12
     min: 4
     max: 50
+    step: 1
     current: None
+    units: "b/min"
 
 # Inspiration/Expiration
 insp_expir_ratio:
+    name: "Insp./Expir."
     default: 0.5
     min: 0.33
     max: 1.
+    step: 0.1
     current: None
+    units: "ratio"
 
 
 

--- a/gui/default_settings.yaml
+++ b/gui/default_settings.yaml
@@ -2,7 +2,7 @@
 port: '/dev/cu.usbmodem141301'
 
 # If false, opens the GUI but doesn't read data:
-read_from_esp: False
+read_from_esp: True
 
 # Number of samples to display in the graphs:
 nsamples: 100

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -23,9 +23,6 @@ DONOT_RUN = 0
 
 
 class MainWindow(QtWidgets.QMainWindow):
-    MODE_STOP   = 0
-    MODE_AUTO   = 1
-    MODE_ASSIST = 2
     def __init__(self, config, esp32, *args, **kwargs):
         """
         Initializes the main window for the MVM GUI. See below for subfunction setup description.
@@ -62,16 +59,13 @@ class MainWindow(QtWidgets.QMainWindow):
         self.toolsettings[..] are the objects that hold min, max values for a given setting as
         as the current value (displayed as a slider and as a number).
         '''
-        self.toolsettings = [];
-        self.toolsettings.append(self.findChild(QtWidgets.QWidget, "toolsettings_1"))
-        self.toolsettings.append(self.findChild(QtWidgets.QWidget, "toolsettings_2"))
-        self.toolsettings.append(self.findChild(QtWidgets.QWidget, "toolsettings_3"))
+        toolsettings_names = {"toolsettings_1", "toolsettings_2", "toolsettings_3"}
+        self.toolsettings = {};
 
-        self.toolsettings[0].setup("Resp. Rate",          setrange=(4.,  12., 100.), units="b/min")
-        self.toolsettings[1].setup("Insp./Expir.",        setrange=(0., 0.5,  10.), units="ratio")
-        self.toolsettings[2].setup("O<sub>2</sub> conc.", setrange=(21, 40, 100), units="%")
-        # self.toolsettings[1].setup("PEEP",                setrange=(0,   5, 50),  units="cmH<sub>2</sub>O")
-
+        for name in toolsettings_names:
+            toolsettings = self.findChild(QtWidgets.QWidget, name)
+            toolsettings.connect_config(config)
+            self.toolsettings[name] = toolsettings
 
         '''
         Set up data monitor/alarms (side bar)
@@ -80,8 +74,8 @@ class MainWindow(QtWidgets.QMainWindow):
         and max. The current value and optional stats for the monitored value (mean, max) are set
         here.
         '''
-        monitor_names = {"monitor_top", "monitor_mid", "monitor_bot"};
-        self.monitors = {};
+        monitor_names = {"monitor_top", "monitor_mid", "monitor_bot"}
+        self.monitors = {}
         monitor_default = {
                 "name": "NoName",
                 "min": 0,

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -101,6 +101,16 @@ class Settings(QtWidgets.QMainWindow):
         self._insp_expir_ratio_input.setMaximum(ie['max'])
         self._current_values['insp_expir_ratio'] = ie['default']
 
+        # assign an easy lookup for toolsettings
+        self.toolsettings_lookup = {}
+        self.toolsettings_lookup["respiratory_rate"] = self._toolsettings["toolsettings_1"]
+        self.toolsettings_lookup["insp_expir_ratio"] = self._toolsettings["toolsettings_2"]
+        
+        # setup the toolsettings with preset values
+        self.toolsettings_lookup["respiratory_rate"].load_presets("respiratory_rate")
+        self.toolsettings_lookup["insp_expir_ratio"].load_presets("insp_expir_ratio")
+
+        # start workers
         self.resp_rate_worker()
         self.insp_expir_ratio_worker()
 
@@ -112,12 +122,6 @@ class Settings(QtWidgets.QMainWindow):
 
         self._current_values_temp = self._current_values
 
-
-        try:
-            self._toolsettings[0].update_range(valuerange=(rr['min'],rr['max']))
-            self._toolsettings[1].update_range(valuerange=(ie['min'],ie['max']))
-        except:
-            pass
 
     def load_presets_assist(self):
 
@@ -222,7 +226,7 @@ class Settings(QtWidgets.QMainWindow):
             self._respiratory_rate_input.setStyleSheet("color: green")
 
         # Finally, update the value in the toolsettings
-        self._toolsettings[0].update(rr)
+        self.toolsettings_lookup["respiratory_rate"].update(rr)
 
 
         #
@@ -246,7 +250,7 @@ class Settings(QtWidgets.QMainWindow):
             self._insp_expir_ratio_input.setStyleSheet("color: green")
 
         # Finally, update the value in the toolsettings
-        self._toolsettings[1].update(1/ratio)
+        self.toolsettings_lookup["insp_expir_ratio"].update(1/ratio)
 
 
     def send_assist_values_to_hardware(self):
@@ -274,7 +278,7 @@ class Settings(QtWidgets.QMainWindow):
             self._pressure_trigger_input.setStyleSheet("color: green")
 
         # Finally, update the value in the toolsettings
-        # self._toolsettings[1].update(ratio)
+        # self.toolsettings_lookup["insp_expir_ratio"].update(1/ratio)
 
         #
         # Flow trigger
@@ -295,7 +299,7 @@ class Settings(QtWidgets.QMainWindow):
             self._flow_trigger_input.setStyleSheet("color: green")
 
         # Finally, update the value in the toolsettings
-        # self._toolsettings[1].update(ratio)
+        # self.toolsettings_lookup["insp_expir_ratio"].update(1/ratio)
 
 
     def resp_rate_worker(self):

--- a/gui/toolsettings/toolsettings.py
+++ b/gui/toolsettings/toolsettings.py
@@ -111,12 +111,8 @@ class ToolSettings(QtWidgets.QWidget):
 
         value: The value that the setting will display.
         """
-        print(self.label_name.text())
         value = round(value / self.step) * self.step
         slider_value = int(self.slider_scale * (value - self.min))
-
-        print(str(self.min) + " " + str(value) + " " + str(self.max))
-        print(str(self.slider_value.minimum()) + " " + str(slider_value) + " " + str(self.slider_value.maximum()))
 
         self.slider_value.setValue(slider_value)
         

--- a/gui/toolsettings/toolsettings.py
+++ b/gui/toolsettings/toolsettings.py
@@ -25,11 +25,10 @@ class ToolSettings(QtWidgets.QWidget):
         palette.setColor(role, QtGui.QColor("#eeeeee"))
         self.setPalette(palette)
 
-
         self.slider_value.valueChanged.connect(self.update)
 
         self.show()
-    def setup(self, name, setrange=(0,0,100), units=None):
+    def setup(self, name, setrange=(0,0,100), units=None, step=0.1, dec_precision=0, current=None):
         """
         Sets up main values for the ToolSettings widget, including the name and the values for the
         range as (minimum, initial, maximum).
@@ -37,16 +36,19 @@ class ToolSettings(QtWidgets.QWidget):
         name: The name to be displayed.
         setrange: Tuple (min, current, max) specifying the allowed min/max values and current value.
         units: String value for the units to be displayed.
+        step: sets the granularity of a single step of the parameter
         """
         self.label_name.setText(name)
 
         # unpack and assign slider min, current, and max
         (low, val, high) = setrange
-        self.slider_value.setMinimum(low)
-        self.slider_value.setMaximum(high)
+        self.update_range(valuerange=(low, high), step=step)
         self.label_min.setText(str(low))
         self.label_max.setText(str(high))
         self.value = val
+        
+        self.dec_precision = dec_precision
+        self.current = current
 
         # Handle optional units
         if units is not None:
@@ -56,9 +58,49 @@ class ToolSettings(QtWidgets.QWidget):
 
         self.update(val)
 
-    def update_range(self, valuerange=(0,1)):
-        self.slider_value.setMinimum(valuerange[0])
-        self.slider_value.setMaximum(valuerange[1])
+    def load_presets(self, name="default"):
+        toolsettings_default = {
+                "name": "Param",
+                "default": 50,
+                "min": 0,
+                "max": 100,
+                "current": None,
+                "units": "-",
+                "step": 1,
+                "dec_precision": 0}
+        entry = self._config.get(name, toolsettings_default)
+        self.setup(
+                entry.get("name", toolsettings_default["name"]),
+                setrange=(
+                    entry.get("min", toolsettings_default["min"]),
+                    entry.get("default", toolsettings_default["default"]),
+                    entry.get("max", toolsettings_default["max"])),
+                units=entry.get("units", toolsettings_default["units"]),
+                step=entry.get("step", toolsettings_default["step"]),
+                current=entry.get("current", toolsettings_default["current"]),
+                dec_precision=entry.get("dec_precision", toolsettings_default["dec_precision"]))
+
+    def connect_config(self, config):
+        self._config = config
+
+    def update_range(self, valuerange=(0,1), step=0.1):
+        """
+        Updates the range of the progress bar widget.
+
+        valuerange: (min, max) for the parameter
+        step: sets the granularity of a single step of the parameter
+        """
+        self.min = valuerange[0]
+        self.max = valuerange[1]
+        self.step = step
+
+        num_steps = 100 * (self.max - self.min) / self.step
+        self.slider_scale = num_steps / (self.max - self.min)
+
+        # set the max for exactly the number of steps we need
+        self.slider_value.setMinimum(0)
+        self.slider_value.setMaximum(num_steps)
+
         self.label_min.setText(str(valuerange[0]))
         self.label_max.setText(str(valuerange[1]))
 
@@ -69,7 +111,14 @@ class ToolSettings(QtWidgets.QWidget):
 
         value: The value that the setting will display.
         """
-        self.slider_value.setValue(value)
+        print(self.label_name.text())
+        value = round(value / self.step) * self.step
+        slider_value = int(self.slider_scale * (value - self.min))
+
+        print(str(self.min) + " " + str(value) + " " + str(self.max))
+        print(str(self.slider_value.minimum()) + " " + str(slider_value) + " " + str(self.slider_value.maximum()))
+
+        self.slider_value.setValue(slider_value)
         
         if isinstance(value, float):
             value = f'{value:.3}'

--- a/gui/toolsettings/toolsettings.ui
+++ b/gui/toolsettings/toolsettings.ui
@@ -266,7 +266,7 @@
          </font>
         </property>
         <property name="text">
-         <string>0</string>
+         <string>42</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -508,7 +508,7 @@
          </palette>
         </property>
         <property name="value">
-         <number>24</number>
+         <number>42</number>
         </property>
         <property name="format">
          <string/>


### PR DESCRIPTION
Fixes #53 
- Slider can now take floating point through conversion 
- Number of control steps per toolsettings can be specified
- All parameters for toolsettings are now specified in default_settings.yaml
- In settings.py, the toolsettings in the GUI ("toolsettings_1") are aliased to a dictionary (settings.toolsettings_lookup) at a given name in the yaml file