### PR TITLE
Issue 79 - Add option to show "looping" plots as well as "scrolling" plots

### DIFF
--- a/gui/data_filler.py
+++ b/gui/data_filler.py
@@ -137,7 +137,7 @@ class DataFiller():
                                          angle=90, 
                                          movable=False,
                                          pen=pg.mkPen(cosmetic=False, 
-                                                      width=self._sampling * 4, 
+                                                      width=self._time_window / 25, 
                                                       color='k',
                                                       style=QtCore.Qt.SolidLine))
 

--- a/gui/data_filler.py
+++ b/gui/data_filler.py
@@ -47,11 +47,11 @@ class DataFiller():
         plot.setLabel(axis='left', text=y_axis_label)
 
         # Set the X axis
-        if self._config['show_x_axis_labels'] and 'bot' in monitor_name:
+        if self._config['show_x_axis_labels'] and 'bot' in monitor_name and not self._looping:
             self.add_x_axis_label(plot)
 
         # Remove x ticks, if selected
-        if not self._config['show_x_axis_ticks']:
+        if self._looping or not self._config['show_x_axis_ticks']:
             plot.getAxis('bottom').setTicks([])
             plot.getAxis('bottom').setStyle(tickTextOffset=0, tickTextHeight=0)
 
@@ -137,9 +137,9 @@ class DataFiller():
                                          angle=90, 
                                          movable=False,
                                          pen=pg.mkPen(cosmetic=False, 
-                                                      width=0, 
-                                                      color='r',
-                                                      style=QtCore.Qt.DotLine))
+                                                      width=self._sampling * 4, 
+                                                      color='k',
+                                                      style=QtCore.Qt.SolidLine))
 
         plot.addItem(self._looping_lines[name])
 
@@ -171,7 +171,7 @@ class DataFiller():
             if self._looping_data_idx[name] == self._n_smaples:
                 self._looping_data_idx[name] = 0
                 
-            x_val = self._xdata[self._looping_data_idx[name]]
+            x_val = self._xdata[self._looping_data_idx[name]] - self._sampling * 0.1
             self._looping_lines[name].setValue(x_val)
         else:
             # Scrolling plots - shift data 1 sample left

--- a/gui/default_settings.yaml
+++ b/gui/default_settings.yaml
@@ -45,6 +45,9 @@ show_x_axis_labels: True
 # Toggles the x axis ticks in the graphs (specifcally, the numbers on the x axis)
 show_x_axis_ticks: True
 
+# Toggles between scrolling plots and looping plots
+use_looping_plots: False
+
 # The units used for each variable:
 var_units: 
     pressure: 'mbar'


### PR DESCRIPTION
When looping, includes an extra vertical line showing where we've got to.

Default is still scrolling. Looping is enabled by setting "use_looping_plots" in the yaml.